### PR TITLE
Handling embedded imgs

### DIFF
--- a/lib/contentful_converter/nokogiri_builder.rb
+++ b/lib/contentful_converter/nokogiri_builder.rb
@@ -46,9 +46,13 @@ module ContentfulConverter
 
       def normalize_imgs(html_node)
         html_node.traverse do |elem|
-          if elem.name == 'img'
-            new_node = create_text_node(elem.to_s, html_node)
-            elem.replace(new_node)
+          next unless elem.name == 'img'
+
+          text_node = create_text_node(elem.to_s, html_node)
+          if elem.parent.name == '#document-fragment' || elem.parent.name == 'p'
+            elem.replace(text_node)
+          else
+            elem.parent.swap(wrap_in_p(text_node))
           end
         end
       end
@@ -98,6 +102,12 @@ module ContentfulConverter
 
       def find_nodes(html_node, element)
         html_node.css(*element)
+      end
+
+      def wrap_in_p(img)
+        p_node = Nokogiri::XML::Node.new('p', img)
+        p_node.content = img
+        p_node
       end
 
       def create_text_node(text, html_node)

--- a/lib/contentful_converter/nokogiri_builder.rb
+++ b/lib/contentful_converter/nokogiri_builder.rb
@@ -52,6 +52,8 @@ module ContentfulConverter
           parent_elem = elem.parent
           if %w[#document-fragment p].include?(parent_elem.name)
             elem.replace(text_node)
+          elsif parent_elem.name == 'a'
+            parent_elem.replace(text_node)
           else
             add_elems_as_siblings(parent_elem, text_node)
           end

--- a/lib/contentful_converter/nokogiri_builder.rb
+++ b/lib/contentful_converter/nokogiri_builder.rb
@@ -49,10 +49,11 @@ module ContentfulConverter
           next unless elem.name == 'img'
 
           text_node = create_text_node(elem.to_s, html_node)
-          if elem.parent.name == '#document-fragment' || elem.parent.name == 'p'
+          parent_elem = elem.parent
+          if %w[#document-fragment p].include?(parent_elem.name)
             elem.replace(text_node)
           else
-            elem.parent.swap(wrap_in_p(text_node))
+            add_img_as_sibling(parent_elem, elem)
           end
         end
       end
@@ -104,10 +105,10 @@ module ContentfulConverter
         html_node.css(*element)
       end
 
-      def wrap_in_p(img)
-        p_node = Nokogiri::XML::Node.new('p', img)
-        p_node.content = img
-        p_node
+      def add_img_as_sibling(parent_elem, elem)
+        valid_children_nodeset = parent_elem.children.css(':not(img)')
+        parent_elem.children = valid_children_nodeset
+        parent_elem.add_next_sibling(elem)
       end
 
       def create_text_node(text, html_node)

--- a/lib/contentful_converter/nokogiri_builder.rb
+++ b/lib/contentful_converter/nokogiri_builder.rb
@@ -53,7 +53,7 @@ module ContentfulConverter
           if %w[#document-fragment p].include?(parent_elem.name)
             elem.replace(text_node)
           else
-            add_img_as_sibling(parent_elem, elem)
+            add_img_as_sibling(parent_elem, text_node)
           end
         end
       end

--- a/lib/contentful_converter/nokogiri_builder.rb
+++ b/lib/contentful_converter/nokogiri_builder.rb
@@ -53,7 +53,7 @@ module ContentfulConverter
           if %w[#document-fragment p].include?(parent_elem.name)
             elem.replace(text_node)
           else
-            add_img_as_sibling(parent_elem, text_node)
+            add_elems_as_siblings(parent_elem, text_node)
           end
         end
       end
@@ -105,8 +105,9 @@ module ContentfulConverter
         html_node.css(*element)
       end
 
-      def add_img_as_sibling(parent_elem, elem)
+      def add_elems_as_siblings(parent_elem, elem)
         valid_children_nodeset = parent_elem.children.css(':not(img)')
+        parent_elem.children.find_all(&:text?).each { |n| valid_children_nodeset.push(n) }
         parent_elem.children = valid_children_nodeset
         parent_elem.add_next_sibling(elem)
       end

--- a/spec/lib/nokogiri_builder_spec.rb
+++ b/spec/lib/nokogiri_builder_spec.rb
@@ -77,7 +77,7 @@ describe ContentfulConverter::NokogiriBuilder do
       end
 
       context 'when the html has an <img> element' do
-        it 'converts the img to text embedded to container tags' do
+        it 'converts the img to text when embedded to container (section,div) or <p> tags' do
           html = '<section>test<img src="test.jpg" /></section>'
           expected_html = 'test&lt;img src="test.jpg"&gt;'
 
@@ -85,15 +85,15 @@ describe ContentfulConverter::NokogiriBuilder do
           expect(result.to_html).to eq(expected_html)
         end
 
-        it 'converts the img to text embedded to <a> or <p> tags' do
-          html = '<a href="https://test.com/" target=""><img src="test.jpg" alt="test" /></a>'
-          expected_html = '&lt;img src="test.jpg" alt="test"&gt;'
+        it 'converts the img to text even if img is a link' do
+          html = '<a href="https://test.com/" target=""><img src="test.jpg" /></a>'
+          expected_html = '&lt;img src="test.jpg"&gt;'
 
           result = described_class.build(html)
           expect(result.to_html).to eq(expected_html)
         end
 
-        it 'makes a new sibling tag when embedded to anything that is not a <p> or <a>' do
+        it 'makes a new sibling tag when embedded to anything that is not a container or <a> tag' do
           html = '<strong>HI <img src="https://getapp.wpengine.com/wp-content/uploads/Top-Rated_Graph-FreshBooks.png" alt=""></strong>'
           expected_html = '<strong>HI </strong>&lt;img src="https://getapp.wpengine.com/wp-content/uploads/Top-Rated_Graph-FreshBooks.png" alt=""&gt;'
 

--- a/spec/lib/nokogiri_builder_spec.rb
+++ b/spec/lib/nokogiri_builder_spec.rb
@@ -77,10 +77,18 @@ describe ContentfulConverter::NokogiriBuilder do
       end
 
       context 'when the html has an <img> element' do
-        let(:html) { '<section>test<img src="test.jpg" /></section>' }
-        let(:expected_html) { 'test&lt;img src="test.jpg"&gt;' }
+        it 'converts the img to text' do
+          html = '<section>test<img src="test.jpg" /></section>'
+          expected_html = 'test&lt;img src="test.jpg"&gt;'
 
-        it 'converts it to embed and moves it out of the paragraph' do
+          result = described_class.build(html)
+          expect(result.to_html).to eq(expected_html)
+        end
+
+        it 'makes a new sibling tag when embedded to anything that is not a <p>' do
+          html = '<strong>HI <img src="https://getapp.wpengine.com/wp-content/uploads/Top-Rated_Graph-FreshBooks.png" alt=""></strong>'
+          expected_html = '<strong>HI </strong>&lt;img src="https://getapp.wpengine.com/wp-content/uploads/Top-Rated_Graph-FreshBooks.png" alt=""&gt;'
+
           result = described_class.build(html)
           expect(result.to_html).to eq(expected_html)
         end

--- a/spec/lib/nokogiri_builder_spec.rb
+++ b/spec/lib/nokogiri_builder_spec.rb
@@ -77,7 +77,7 @@ describe ContentfulConverter::NokogiriBuilder do
       end
 
       context 'when the html has an <img> element' do
-        it 'converts the img to text' do
+        it 'converts the img to text embedded to container tags' do
           html = '<section>test<img src="test.jpg" /></section>'
           expected_html = 'test&lt;img src="test.jpg"&gt;'
 
@@ -85,7 +85,15 @@ describe ContentfulConverter::NokogiriBuilder do
           expect(result.to_html).to eq(expected_html)
         end
 
-        it 'makes a new sibling tag when embedded to anything that is not a <p>' do
+        it 'converts the img to text embedded to <a> or <p> tags' do
+          html = '<a href="https://test.com/" target=""><img src="test.jpg" alt="test" /></a>'
+          expected_html = '&lt;img src="test.jpg" alt="test"&gt;'
+
+          result = described_class.build(html)
+          expect(result.to_html).to eq(expected_html)
+        end
+
+        it 'makes a new sibling tag when embedded to anything that is not a <p> or <a>' do
           html = '<strong>HI <img src="https://getapp.wpengine.com/wp-content/uploads/Top-Rated_Graph-FreshBooks.png" alt=""></strong>'
           expected_html = '<strong>HI </strong>&lt;img src="https://getapp.wpengine.com/wp-content/uploads/Top-Rated_Graph-FreshBooks.png" alt=""&gt;'
 


### PR DESCRIPTION
Related to https://getapp.atlassian.net/browse/GETAPP-6947

Addressing issue on cell E9 and E10 https://docs.google.com/spreadsheets/d/13jtGKl2bCNiLUnYNGNiIibLaEPIXUxeUgX-Ro1zyo9w/edit#gid=0

Before:
<img width="1118" alt="Screenshot 2020-04-02 at 16 52 42" src="https://user-images.githubusercontent.com/25816956/78263582-7023cc00-7502-11ea-8fd9-f4bc523d78ee.png">

After:
<img width="804" alt="Screenshot 2020-04-02 at 16 52 55" src="https://user-images.githubusercontent.com/25816956/78263603-76b24380-7502-11ea-93b9-fe70da4370d0.png">

URLs for comparison:

Old: https://getapp-resources.herokuapp.com/preview/alternatives-sage-50-small-business-consider
New: https://getapp-resources.herokuapp.com/preview/migration-test-alternatives-sage-50-small-business-consider
Old: https://getapp-resources.herokuapp.com/preview/5-top-rated-accounting-software-apps-for-independent-contractors
New: https://getapp-resources.herokuapp.com/preview/migration-test-5-top-rated-accounting-software-apps-for-independent-contractors